### PR TITLE
feat(smoke-tests): extend smoke test suite with performance optimizations and documentation coverage

### DIFF
--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -38,6 +38,14 @@ All test cases use a consistent 2-tag pattern: **`@feature @type`**
 
 ## Test Cases
 
+### Smoke Tests
+
+- **Homepage** `@e2e @smoke`: Load homepage → page title contains "Rolnopol"
+- **Login page load** `@auth @smoke`: Navigate to /login.html → login page loads with correct subtitle
+- **Register page load** `@auth @smoke`: Navigate to /register.html → register page loads with correct subtitle
+- **Docs UI** `@api @smoke`: Access /docs.html → documentation page loads with correct subtitle
+- **Swagger UI** `@api @smoke`: Access /swagger.html → API documentation loads in iframe
+
 ### Authentication
 
 - **Registration** `@auth @regression`: New user creates account → auto-login, redirected to dashboard
@@ -84,7 +92,6 @@ All test cases use a consistent 2-tag pattern: **`@feature @type`**
 - **Health check** `@api @smoke`: GET health endpoint → status returned
 - **No auth** `@api @negative`: API request without token → 401 Unauthorized
 - **With auth** `@api @smoke`: API request with valid token → successful response
-- **Swagger UI** `@api @smoke`: Access /swagger.html → documentation loads
 
 ---
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   testDir: './tests',
   timeout: 30 * 1000,
   expect: {
-    timeout: 10 * 1000,
+    timeout: 5 * 1000,
   },
   fullyParallel: true,
   forbidOnly: !!process.env.CI,

--- a/tests/main.smoke.spec.ts
+++ b/tests/main.smoke.spec.ts
@@ -21,17 +21,19 @@ test('should load register page', { tag: ['@auth', '@smoke'] }, async ({ page })
   await expect(page.getByTestId('register-subtitle')).toHaveText(expectedSubtitle);
 });
 
-test('should load docs page', { tag: '@smoke' }, async ({ page }) => {
+test('should load docs page', { tag: ['@smoke', '@documentation'] }, async ({ page }) => {
   const expectedSubtitle = 'Rolnopol System Guide & API Reference';
 
   await page.goto('/docs.html');
   await expect(page.locator('.docs-header-subtitle')).toHaveText(expectedSubtitle);
 });
 
-test('should load swagger page', { tag: '@smoke' }, async ({ page }) => {
+test('should load swagger page', { tag: ['@smoke', '@documentation'] }, async ({ page }) => {
   const expectedDescription = 'API documentation for the Rolnopol service with versioning support';
 
   await page.goto('/swagger.html');
   const iframe = page.frameLocator('iframe#swagger-frame');
-  await expect(iframe.locator('.information-container .renderedMarkdown')).toHaveText(expectedDescription);
+  await expect(iframe.locator('.information-container .renderedMarkdown')).toHaveText(
+    expectedDescription
+  );
 });

--- a/tests/main.smoke.spec.ts
+++ b/tests/main.smoke.spec.ts
@@ -8,15 +8,16 @@ test('should display page with Rolnopol title on homepage', { tag: '@smoke' }, a
 });
 
 test('should load login page', { tag: ['@auth', '@smoke'] }, async ({ page }) => {
+  const expectedSubtitle = 'User Login & Account Access';
+
   const response = await page.goto('/login.html');
-  expect(response).not.toBeNull();
-  expect(response?.ok()).toBeTruthy();
-  await expect(page.locator('body')).toBeVisible();
+  await expect(page.getByTestId('login-subtitle')).toHaveText(expectedSubtitle);
 });
 
 test('should load register page', { tag: ['@auth', '@smoke'] }, async ({ page }) => {
+  const expectedSubtitle = 'Create Your User Account';
+
   const response = await page.goto('/register.html');
-  expect(response).not.toBeNull();
-  expect(response?.ok()).toBeTruthy();
-  await expect(page.locator('body')).toBeVisible();
+  await expect(page.getByTestId('register-subtitle')).toHaveText(expectedSubtitle);
 });
+

--- a/tests/main.smoke.spec.ts
+++ b/tests/main.smoke.spec.ts
@@ -10,14 +10,28 @@ test('should display page with Rolnopol title on homepage', { tag: '@smoke' }, a
 test('should load login page', { tag: ['@auth', '@smoke'] }, async ({ page }) => {
   const expectedSubtitle = 'User Login & Account Access';
 
-  const response = await page.goto('/login.html');
+  await page.goto('/login.html');
   await expect(page.getByTestId('login-subtitle')).toHaveText(expectedSubtitle);
 });
 
 test('should load register page', { tag: ['@auth', '@smoke'] }, async ({ page }) => {
   const expectedSubtitle = 'Create Your User Account';
 
-  const response = await page.goto('/register.html');
+  await page.goto('/register.html');
   await expect(page.getByTestId('register-subtitle')).toHaveText(expectedSubtitle);
 });
 
+test('should load docs page', { tag: '@smoke' }, async ({ page }) => {
+  const expectedSubtitle = 'Rolnopol System Guide & API Reference';
+
+  await page.goto('/docs.html');
+  await expect(page.locator('.docs-header-subtitle')).toHaveText(expectedSubtitle);
+});
+
+test('should load swagger page', { tag: '@smoke' }, async ({ page }) => {
+  const expectedDescription = 'API documentation for the Rolnopol service with versioning support';
+
+  await page.goto('/swagger.html');
+  const iframe = page.frameLocator('iframe#swagger-frame');
+  await expect(iframe.locator('.information-container .renderedMarkdown')).toHaveText(expectedDescription);
+});


### PR DESCRIPTION
This PR extends the smoke test suite by enhancing authentication tests, adding documentation page tests, and optimizing test performance.

**Changes:**
- Tests: Enhanced auth smoke tests with specific subtitle assertions for better validation.
- Tests: Added smoke tests for docs and swagger UI pages with @documentation tagging.
- Config: Reduced expect timeout from 10s to 5s for improved test execution speed.
- Documentation: Updated test plan with dedicated smoke tests section and refined API test listings.

**Testing:**
- All smoke tests pass with the new assertions and reduced timeouts.
- Maintains compatibility with existing test infrastructure.