### PR TITLE
Add create-pr prompt for PR automation

### DIFF
--- a/.github/prompts/create-pr.prompt.md
+++ b/.github/prompts/create-pr.prompt.md
@@ -1,0 +1,13 @@
+---
+name: create-pr
+description: Opens Pull Request on GitHub.
+agent: agent
+model: GPT-5 mini (copilot)
+---
+
+When creating a new Pull Request, follow these steps with the help of Github MCP Server:
+
+1. Create a new branch with a name based on the recent changes.
+2. Commit the changes to the new branch and push them to the remote repository.
+3. Create a clear and concise title and description for the Pull Request with the help of 'pr-title-description' prompt.
+4. Open a Pull Request on GitHub.


### PR DESCRIPTION
This PR adds a new GitHub prompt file at `.github/prompts/create-pr.prompt.md` that documents steps for creating a Pull Request using the GitHub MCP Server: create a branch, commit the changes, generate a PR title and description, and open the PR. No runtime code changes.

Files changed:
- .github/prompts/create-pr.prompt.md

Reason: add guidance to standardize PR creation in this repository.