### PR TITLE
feat(self-heal): extend self-healing and sync TEST_PLAN

### DIFF
--- a/.github/prompts/create-pr.prompt.md
+++ b/.github/prompts/create-pr.prompt.md
@@ -7,6 +7,7 @@ model: GPT-5 mini (copilot)
 
 When creating a new Pull Request, follow these steps with the help of Github MCP Server:
 
+0. Add all the modified files to a new branch
 1. If any new tests were added or existing tests were updated, ensure that the TEST_PLAN.md file is updated accordingly using the 'sync-test-plan' prompt
 2. Commit the changes to the new branch and push them to the remote repository
 3. Create a clear and concise title and description for the Pull Request with the help of 'pr-title-description' prompt

--- a/.github/workflows/playwright-e2e-tests.yml
+++ b/.github/workflows/playwright-e2e-tests.yml
@@ -50,8 +50,7 @@ jobs:
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
-          restore-keys: playwright-${{ runner.os }}-
+          key: playwright-${{ steps.pw-version.outputs.version }}
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -61,9 +61,11 @@ All test cases use a consistent 2-tag pattern: **`@feature @type`**
 - **Empty form submission** `@auth @negative @registration`: Submit empty form → validation error on required fields ✅
 - **Invalid email without @** `@auth @negative @registration`: Email without @ symbol → validation error mentioning @ ✅
 - **Email with spaces** `@auth @negative @registration`: Email containing spaces → validation error shown ✅
+- **Invalid email variants tested** `@auth @negative @registration`: cases like `invalid-email`, `test@`, `@example.com`, `test@example`, `test@.com`, `test @example.com` → validation error shown ✅
 - **Password too short** `@auth @negative @registration`: Password with less than 3 characters → validation error shown ✅
 - **Display name too short** `@auth @negative @registration`: Display name with less than 3 characters → validation error shown ✅
 - **Display name truncation** `@auth @negative @registration`: Display name exceeding 20 characters → automatically truncated to 20 chars ✅
+  - **Truncation detail**: long names are truncated to exactly 20 characters (e.g. "ThisIsAVeryLongDispl") ✅
 - **Duplicate email** `@auth @negative @registration`: Register with existing email → error message "User with this email already exists" ✅
 - **Whitespace-only password** `@auth @negative @registration`: Password with only spaces → error message "Password must be at least 3 characters long" ✅
 

--- a/scripts/heal.ts
+++ b/scripts/heal.ts
@@ -3,10 +3,6 @@
  *
  * Usage:
  *   OPENAI_API_KEY=sk-... npx tsx scripts/heal.ts
- *
- * For PR creation also set:
- *   GITHUB_TOKEN=ghp_...
- *   GITHUB_REPOSITORY=owner/repo
  */
 import { execSync } from 'child_process';
 import fs from 'fs';
@@ -44,6 +40,10 @@ async function callAi(context: HealingContext): Promise<AiResponse> {
           .join('\n\n')
       : '_No page objects found._';
 
+  const domTreeSection = context.failure.domTree
+    ? `## Page DOM Tree at Failure\n\`\`\`json\n${JSON.stringify(context.failure.domTree, null, 2)}\n\`\`\``
+    : '';
+
   const prompt = `You are a Playwright test repair agent.
 A test has failed, most likely because the UI changed (e.g. a locator selector, test-id, or visible text is now different).
 
@@ -62,10 +62,14 @@ ${context.failure.errorMessage}
 ${context.failure.errorStack}
 \`\`\`
 
+## DOM Tree
+${domTreeSection}
+
 ## Rules
 - Only fix locators, text values, or selectors directly related to the reported error.
 - Do NOT change test logic, add comments, or refactor anything unrelated to the failure.
 - Follow the Page Object Pattern: locators belong in page object files; assertions stay in test files.
+- If the DOM tree is provided, use it to identify the correct selector, text, or structure that replaced what the test was looking for.
 - Return ONLY valid JSON matching this exact schema — no markdown, no explanation outside JSON:
 
 {

--- a/src/fixtures/index.ts
+++ b/src/fixtures/index.ts
@@ -1,0 +1,84 @@
+import { test as base } from '@playwright/test';
+
+const SKIP_TAGS = new Set(['script', 'style', 'noscript', 'template', 'svg', 'path', 'defs']);
+const CAPTURED_ATTRS = [
+  'id',
+  'class',
+  'data-testid',
+  'aria-label',
+  'role',
+  'name',
+  'type',
+  'placeholder',
+  'href',
+];
+const MAX_DEPTH = 8;
+const MAX_TEXT_LENGTH = 120;
+
+/** Playwright auto-fixture that attaches a simplified DOM tree to every failing test. */
+export const test = base.extend<{ _domCapture: void }>({
+  _domCapture: [
+    async ({ page }, use, testInfo) => {
+      await use();
+
+      if (testInfo.status === 'failed' || testInfo.status === 'timedOut') {
+        try {
+          const domTree = await page.evaluate(
+            ({ skipTags, capturedAttrs, maxDepth, maxTextLength }) => {
+              interface DomNode {
+                tag: string;
+                [attr: string]: unknown;
+                children?: DomNode[];
+                text?: string;
+              }
+
+              function buildNode(el: Element, depth: number): DomNode | null {
+                if (depth > maxDepth || skipTags.has(el.tagName.toLowerCase())) return null;
+
+                const node: DomNode = { tag: el.tagName.toLowerCase() };
+
+                for (const attr of capturedAttrs) {
+                  const val = el.getAttribute(attr);
+                  if (val?.trim()) node[attr] = val.trim();
+                }
+
+                const childNodes = Array.from(el.children)
+                  .map((child) => buildNode(child, depth + 1))
+                  .filter((c): c is DomNode => c !== null);
+
+                if (childNodes.length > 0) {
+                  node.children = childNodes;
+                } else {
+                  const text = el.textContent?.trim();
+                  if (text) node.text = text.slice(0, maxTextLength);
+                }
+
+                return node;
+              }
+
+              return document.body ? buildNode(document.body, 0) : null;
+            },
+            {
+              skipTags: [...SKIP_TAGS],
+              capturedAttrs: CAPTURED_ATTRS,
+              maxDepth: MAX_DEPTH,
+              maxTextLength: MAX_TEXT_LENGTH,
+            }
+          );
+
+          if (domTree) {
+            await testInfo.attach('dom-tree', {
+              body: JSON.stringify(domTree, null, 2),
+              contentType: 'application/json',
+            });
+          }
+        } catch {
+          // Page may be closed or unreachable after a hard failure — skip silently.
+        }
+      }
+    },
+    { auto: true },
+  ],
+});
+
+export { expect } from '@playwright/test';

--- a/src/reporters/failure-reporter.ts
+++ b/src/reporters/failure-reporter.ts
@@ -12,6 +12,8 @@ export interface FailureRecord {
   screenshotPath?: string;
   tracePath?: string;
   tags: string[];
+  /** Simplified DOM tree of the page captured at the moment of failure. */
+  domTree?: Record<string, unknown>;
 }
 
 class FailureReporter implements Reporter {
@@ -23,11 +25,26 @@ class FailureReporter implements Reporter {
   }
 
   onTestEnd(test: TestCase, result: TestResult): void {
-    if (result.status !== 'failed') return;
+    if (result.status !== 'failed' && result.status !== 'timedOut') return;
 
     const error = result.errors[0];
     const screenshot = result.attachments.find((a) => a.name === 'screenshot');
     const trace = result.attachments.find((a) => a.name === 'trace');
+    const domTreeAttachment = result.attachments.find((a) => a.name === 'dom-tree');
+
+    let domTree: Record<string, unknown> | undefined;
+    if (domTreeAttachment) {
+      try {
+        const raw = domTreeAttachment.body
+          ? domTreeAttachment.body.toString('utf-8')
+          : domTreeAttachment.path
+            ? fs.readFileSync(domTreeAttachment.path, 'utf-8')
+            : undefined;
+        if (raw) domTree = JSON.parse(raw) as Record<string, unknown>;
+      } catch {
+        // Malformed attachment — skip
+      }
+    }
 
     this.failures.push({
       testTitle: test.title,
@@ -38,6 +55,7 @@ class FailureReporter implements Reporter {
       screenshotPath: screenshot?.path,
       tracePath: trace?.path,
       tags: test.tags,
+      domTree,
     });
   }
 

--- a/tests/main.smoke.spec.ts
+++ b/tests/main.smoke.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../src/fixtures';
 import { DocsPage } from '../src/pages/docs.page';
 import { HomePage } from '../src/pages/home.page';
 import { LoginPage } from '../src/pages/login.page';

--- a/tests/registration.negative.spec.ts
+++ b/tests/registration.negative.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../src/fixtures';
 import { generateUniqueEmail } from '../src/helpers/testDataHelper';
 import { RegisterPage } from '../src/pages/register.page';
 

--- a/tests/registration.positive.spec.ts
+++ b/tests/registration.positive.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from '../src/fixtures';
 import { generateUniqueEmail } from '../src/helpers/testDataHelper';
 import { RegisterPage } from '../src/pages/register.page';
 


### PR DESCRIPTION
This PR extends the self-healing script and synchronizes test documentation.

Changes:
- Updated `TEST_PLAN.md` to list invalid-email variants and display-name truncation details
- Modified test files: `tests/main.smoke.spec.ts`, `tests/registration.negative.spec.ts`, `tests/registration.positive.spec.ts`
- Updated `scripts/heal.ts` and `src/reporters/failure-reporter.ts`
- Added `src/fixtures/index.ts`
- Updated prompt: `.github/prompts/create-pr.prompt.md`

Why:
- Keep the test plan in sync with test updates and improve self-healing behavior when failures are detected.

Notes:
- All changes are on branch `feat/self-healing-extend`.